### PR TITLE
feat: add model plugin architecture

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,7 @@
+TEXT_MODEL_API_KEY=your_text_api_key
+TEXT_MODEL_ENDPOINT=https://api.textmodel.com/generate
+IMAGE_MODEL_API_KEY=your_image_api_key
+IMAGE_MODEL_ENDPOINT=https://api.imagemodel.com/generate
+AUDIO_MODEL_API_KEY=your_audio_api_key
+AUDIO_MODEL_ENDPOINT=https://api.audiomodel.com/generate
+REQUEST_TIMEOUT=5000

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/models/audio/speech.js
+++ b/models/audio/speech.js
@@ -1,0 +1,18 @@
+const { BaseModel } = require('../base');
+
+class SpeechAudioModel extends BaseModel {
+  constructor() {
+    super(process.env.AUDIO_MODEL_API_KEY || '', process.env.AUDIO_MODEL_ENDPOINT || '');
+  }
+
+  async generate(params) {
+    try {
+      return await super.generate(params);
+    } catch (err) {
+      throw new Error(`Audio model failed: ${err.message}`);
+    }
+  }
+}
+
+module.exports = SpeechAudioModel;
+module.exports.default = SpeechAudioModel;

--- a/models/base.js
+++ b/models/base.js
@@ -1,0 +1,50 @@
+/**
+ * @typedef {Object<string, any>} GenerateParams
+ * @typedef {Object<string, any>} Output
+ *
+ * @interface Model
+ * @function generate
+ * @param {GenerateParams} params
+ * @returns {Promise<Output>}
+ */
+
+/**
+ * BaseModel provides a generic request handler with timeout and error handling.
+ */
+class BaseModel {
+  constructor(apiKey, endpoint, timeout = Number(process.env.REQUEST_TIMEOUT) || 5000) {
+    this.apiKey = apiKey;
+    this.endpoint = endpoint;
+    this.timeout = timeout;
+  }
+
+  /**
+   * @param {GenerateParams} params
+   * @returns {Promise<Output>}
+   */
+  async generate(params) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeout);
+    try {
+      const response = await fetch(this.endpoint, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${this.apiKey}`
+        },
+        body: JSON.stringify(params),
+        signal: controller.signal
+      });
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      return await response.json();
+    } catch (err) {
+      throw new Error(err.message || 'Unknown error');
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+}
+
+module.exports = { BaseModel };

--- a/models/image/stableDiffusion.js
+++ b/models/image/stableDiffusion.js
@@ -1,0 +1,18 @@
+const { BaseModel } = require('../base');
+
+class StableDiffusionImageModel extends BaseModel {
+  constructor() {
+    super(process.env.IMAGE_MODEL_API_KEY || '', process.env.IMAGE_MODEL_ENDPOINT || '');
+  }
+
+  async generate(params) {
+    try {
+      return await super.generate(params);
+    } catch (err) {
+      throw new Error(`Image model failed: ${err.message}`);
+    }
+  }
+}
+
+module.exports = StableDiffusionImageModel;
+module.exports.default = StableDiffusionImageModel;

--- a/models/registry.js
+++ b/models/registry.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const path = require('path');
+
+// simple .env loader
+(function loadEnv() {
+  const envPath = path.resolve(process.cwd(), '.env');
+  if (fs.existsSync(envPath)) {
+    const lines = fs.readFileSync(envPath, 'utf-8').split(/\r?\n/);
+    for (const line of lines) {
+      const match = line.match(/^\s*([^#=]+)\s*=\s*(.*)\s*$/);
+      if (match) {
+        const [, key, value] = match;
+        if (!process.env[key]) process.env[key] = value;
+      }
+    }
+  }
+})();
+
+const registry = {};
+
+function loadModels() {
+  const modelsDir = __dirname;
+  const categories = fs.readdirSync(modelsDir, { withFileTypes: true }).filter(d => d.isDirectory());
+  for (const category of categories) {
+    const categoryDir = path.join(modelsDir, category.name);
+    const files = fs.readdirSync(categoryDir);
+    for (const file of files) {
+      if (file.endsWith('.js')) {
+        const mod = require(path.join(categoryDir, file));
+        const ModelClass = mod.default || mod;
+        if (typeof ModelClass === 'function') {
+          const name = `${category.name}/${path.basename(file, '.js')}`;
+          registry[name] = ModelClass;
+        }
+      }
+    }
+  }
+}
+
+function getModel(name) {
+  const ModelClass = registry[name];
+  if (!ModelClass) throw new Error(`Model ${name} not found`);
+  return new ModelClass();
+}
+
+function listModels() {
+  return Object.keys(registry);
+}
+
+module.exports = { loadModels, getModel, listModels };

--- a/models/registry.test.js
+++ b/models/registry.test.js
@@ -1,0 +1,4 @@
+const { loadModels, listModels } = require('./registry');
+
+loadModels();
+console.log('available models:', listModels());

--- a/models/text/openai.js
+++ b/models/text/openai.js
@@ -1,0 +1,18 @@
+const { BaseModel } = require('../base');
+
+class OpenAITextModel extends BaseModel {
+  constructor() {
+    super(process.env.TEXT_MODEL_API_KEY || '', process.env.TEXT_MODEL_ENDPOINT || '');
+  }
+
+  async generate(params) {
+    try {
+      return await super.generate(params);
+    } catch (err) {
+      throw new Error(`Text model failed: ${err.message}`);
+    }
+  }
+}
+
+module.exports = OpenAITextModel;
+module.exports.default = OpenAITextModel;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "solid-chainsaw",
+  "version": "1.0.0",
+  "license": "MIT",
+  "scripts": {
+    "test": "node models/registry.test.js"
+  }
+}


### PR DESCRIPTION
## Summary
- add shared BaseModel interface with timeout-protected generate
- implement text, image, and audio adapters using environment-configured endpoints
- build registry that loads models automatically for plugin-style expansion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6890b31af98c83228d6213c855c918fb