### PR TITLE
feat: add PostgreSQL schema and tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src/__tests__']
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "solid-chainsaw",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "typeorm": "^0.3.17",
+    "reflect-metadata": "^0.1.13",
+    "pg": "^8.11.0",
+    "uuid": "^9.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "ts-node": "^10.9.1",
+    "ts-jest": "^29.1.1",
+    "jest": "^29.5.0",
+    "@types/jest": "^29.5.0",
+    "pg-mem": "^2.1.2",
+    "@types/uuid": "^9.0.0"
+  }
+}

--- a/src/__tests__/crud.test.ts
+++ b/src/__tests__/crud.test.ts
@@ -1,0 +1,89 @@
+import { DataSource } from 'typeorm';
+import { createTestDataSource } from '../utils/test-datasource';
+import { Experiment } from '../entity/Experiment';
+import { Model } from '../entity/Model';
+import { Output } from '../entity/Output';
+import { AnalysisResult } from '../entity/AnalysisResult';
+
+describe('CRUD operations', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = await createTestDataSource();
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  test('experiment CRUD', async () => {
+    const repo = dataSource.getRepository(Experiment);
+    const exp = repo.create({ name: 'exp1' });
+    await repo.save(exp);
+    expect(await repo.findOneBy({ id: exp.id })).not.toBeNull();
+    exp.name = 'exp2';
+    await repo.save(exp);
+    expect((await repo.findOneBy({ id: exp.id }))?.name).toBe('exp2');
+    await repo.remove(exp);
+    expect(await repo.findOneBy({ id: exp.id })).toBeNull();
+  });
+
+  test('model CRUD', async () => {
+    const repo = dataSource.getRepository(Model);
+    const model = repo.create({ name: 'm1' });
+    await repo.save(model);
+    expect(await repo.findOneBy({ id: model.id })).not.toBeNull();
+    model.name = 'm2';
+    await repo.save(model);
+    expect((await repo.findOneBy({ id: model.id }))?.name).toBe('m2');
+    await repo.remove(model);
+    expect(await repo.findOneBy({ id: model.id })).toBeNull();
+  });
+
+  test('output CRUD', async () => {
+    const expRepo = dataSource.getRepository(Experiment);
+    const modelRepo = dataSource.getRepository(Model);
+    const outputRepo = dataSource.getRepository(Output);
+
+    const exp = await expRepo.save(expRepo.create({ name: 'exp' }));
+    const model = await modelRepo.save(modelRepo.create({ name: 'model' }));
+    const output = outputRepo.create({
+      experiment: exp,
+      model: model,
+      s3Path: 's3://bucket/file',
+      metadata: { foo: 'bar' }
+    });
+    await outputRepo.save(output);
+    expect(await outputRepo.findOne({ where: { id: output.id }, relations: ['experiment', 'model'] })).not.toBeNull();
+    output.s3Path = 's3://bucket/updated';
+    await outputRepo.save(output);
+    expect((await outputRepo.findOneBy({ id: output.id }))?.s3Path).toBe('s3://bucket/updated');
+    await outputRepo.remove(output);
+    expect(await outputRepo.findOneBy({ id: output.id })).toBeNull();
+  });
+
+  test('analysis result CRUD', async () => {
+    const expRepo = dataSource.getRepository(Experiment);
+    const modelRepo = dataSource.getRepository(Model);
+    const outputRepo = dataSource.getRepository(Output);
+    const arRepo = dataSource.getRepository(AnalysisResult);
+
+    const exp = await expRepo.save(expRepo.create({ name: 'exp' }));
+    const model = await modelRepo.save(modelRepo.create({ name: 'model' }));
+    const output = await outputRepo.save(outputRepo.create({
+      experiment: exp,
+      model: model,
+      s3Path: 's3://bucket/file',
+      metadata: { foo: 'bar' }
+    }));
+
+    const ar = arRepo.create({ output, data: { result: 1 } });
+    await arRepo.save(ar);
+    expect(await arRepo.findOne({ where: { id: ar.id }, relations: ['output'] })).not.toBeNull();
+    ar.data = { result: 2 };
+    await arRepo.save(ar);
+    expect((await arRepo.findOneBy({ id: ar.id }))?.data).toEqual({ result: 2 });
+    await arRepo.remove(ar);
+    expect(await arRepo.findOneBy({ id: ar.id })).toBeNull();
+  });
+});

--- a/src/data-source.ts
+++ b/src/data-source.ts
@@ -1,0 +1,16 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { Experiment } from './entity/Experiment';
+import { Model } from './entity/Model';
+import { Output } from './entity/Output';
+import { AnalysisResult } from './entity/AnalysisResult';
+import { Init1699999999999 } from './migration/1699999999999-Init';
+
+export const AppDataSource = new DataSource({
+  type: 'postgres',
+  url: process.env.DATABASE_URL,
+  synchronize: false,
+  logging: false,
+  entities: [Experiment, Model, Output, AnalysisResult],
+  migrations: [Init1699999999999],
+});

--- a/src/entity/AnalysisResult.ts
+++ b/src/entity/AnalysisResult.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, ManyToOne, BeforeInsert } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { Output } from './Output';
+
+@Entity('analysis_results')
+export class AnalysisResult {
+  @PrimaryColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Output, (output) => output.analysisResults, { nullable: false })
+  output!: Output;
+
+  @Column({ type: 'jsonb' })
+  data!: any;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @BeforeInsert()
+  generateId() {
+    this.id = uuidv4();
+  }
+}

--- a/src/entity/Experiment.ts
+++ b/src/entity/Experiment.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, OneToMany, BeforeInsert } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { Output } from './Output';
+
+@Entity('experiments')
+export class Experiment {
+  @PrimaryColumn('uuid')
+  id!: string;
+
+  @Column()
+  name!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @OneToMany(() => Output, (output) => output.experiment)
+  outputs!: Output[];
+
+  @BeforeInsert()
+  generateId() {
+    this.id = uuidv4();
+  }
+}

--- a/src/entity/Model.ts
+++ b/src/entity/Model.ts
@@ -1,0 +1,23 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, OneToMany, BeforeInsert } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { Output } from './Output';
+
+@Entity('models')
+export class Model {
+  @PrimaryColumn('uuid')
+  id!: string;
+
+  @Column()
+  name!: string;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @OneToMany(() => Output, (output) => output.model)
+  outputs!: Output[];
+
+  @BeforeInsert()
+  generateId() {
+    this.id = uuidv4();
+  }
+}

--- a/src/entity/Output.ts
+++ b/src/entity/Output.ts
@@ -1,0 +1,37 @@
+import { Entity, PrimaryColumn, Column, CreateDateColumn, ManyToOne, OneToMany, BeforeInsert, Index } from 'typeorm';
+import { v4 as uuidv4 } from 'uuid';
+import { Experiment } from './Experiment';
+import { Model } from './Model';
+import { AnalysisResult } from './AnalysisResult';
+
+@Entity('outputs')
+@Index('idx_outputs_experiment_id', ['experiment'])
+@Index('idx_outputs_model_id', ['model'])
+@Index('idx_outputs_created_at', ['createdAt'])
+export class Output {
+  @PrimaryColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Experiment, (experiment) => experiment.outputs, { nullable: false })
+  experiment!: Experiment;
+
+  @ManyToOne(() => Model, (model) => model.outputs, { nullable: false })
+  model!: Model;
+
+  @Column({ name: 's3_path' })
+  s3Path!: string;
+
+  @Column({ type: 'jsonb' })
+  metadata!: any;
+
+  @CreateDateColumn({ name: 'created_at' })
+  createdAt!: Date;
+
+  @OneToMany(() => AnalysisResult, (ar) => ar.output)
+  analysisResults!: AnalysisResult[];
+
+  @BeforeInsert()
+  generateId() {
+    this.id = uuidv4();
+  }
+}

--- a/src/migration/1699999999999-Init.ts
+++ b/src/migration/1699999999999-Init.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class Init1699999999999 implements MigrationInterface {
+  name = 'Init1699999999999';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`CREATE TABLE "experiments" ("id" uuid NOT NULL, "name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_experiments_id" PRIMARY KEY ("id"))`);
+    await queryRunner.query(`CREATE TABLE "models" ("id" uuid NOT NULL, "name" character varying NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), CONSTRAINT "PK_models_id" PRIMARY KEY ("id"))`);
+    await queryRunner.query(`CREATE TABLE "outputs" ("id" uuid NOT NULL, "s3_path" character varying NOT NULL, "metadata" jsonb NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "experiment_id" uuid, "model_id" uuid, CONSTRAINT "PK_outputs_id" PRIMARY KEY ("id"), CONSTRAINT "FK_outputs_experiment" FOREIGN KEY ("experiment_id") REFERENCES "experiments"("id"), CONSTRAINT "FK_outputs_model" FOREIGN KEY ("model_id") REFERENCES "models"("id"))`);
+    await queryRunner.query(`CREATE TABLE "analysis_results" ("id" uuid NOT NULL, "data" jsonb NOT NULL, "created_at" TIMESTAMP NOT NULL DEFAULT now(), "output_id" uuid, CONSTRAINT "PK_analysis_results_id" PRIMARY KEY ("id"), CONSTRAINT "FK_analysis_output" FOREIGN KEY ("output_id") REFERENCES "outputs"("id"))`);
+    await queryRunner.query(`CREATE INDEX "idx_outputs_experiment_id" ON "outputs" ("experiment_id")`);
+    await queryRunner.query(`CREATE INDEX "idx_outputs_model_id" ON "outputs" ("model_id")`);
+    await queryRunner.query(`CREATE INDEX "idx_outputs_created_at" ON "outputs" ("created_at")`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "idx_outputs_created_at"`);
+    await queryRunner.query(`DROP INDEX "idx_outputs_model_id"`);
+    await queryRunner.query(`DROP INDEX "idx_outputs_experiment_id"`);
+    await queryRunner.query(`DROP TABLE "analysis_results"`);
+    await queryRunner.query(`DROP TABLE "outputs"`);
+    await queryRunner.query(`DROP TABLE "models"`);
+    await queryRunner.query(`DROP TABLE "experiments"`);
+  }
+}

--- a/src/utils/test-datasource.ts
+++ b/src/utils/test-datasource.ts
@@ -1,0 +1,22 @@
+import { DataSource } from 'typeorm';
+import { newDb } from 'pg-mem';
+import { v4 as uuidv4 } from 'uuid';
+import { Experiment } from '../entity/Experiment';
+import { Model } from '../entity/Model';
+import { Output } from '../entity/Output';
+import { AnalysisResult } from '../entity/AnalysisResult';
+import { Init1699999999999 } from '../migration/1699999999999-Init';
+
+export async function createTestDataSource(): Promise<DataSource> {
+  const db = newDb({ autoCreateForeignKeyIndices: true });
+  db.public.registerFunction({ name: 'uuid_generate_v4', returns: 'uuid', implementation: uuidv4 });
+
+  const ds = await db.adapters.createTypeormDataSource({
+    type: 'postgres',
+    entities: [Experiment, Model, Output, AnalysisResult],
+    migrations: [Init1699999999999],
+  });
+  await ds.initialize();
+  await ds.runMigrations();
+  return ds;
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "outDir": "dist",
+    "sourceMap": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add TypeORM setup for PostgreSQL
- define experiments, models, outputs, and analysis_results tables
- include CRUD unit tests for all entities

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6890b32322508322a1fa0e21e492a7a0