### PR TITLE
feat: log scheduler errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+*.log

--- a/scheduler/index.js
+++ b/scheduler/index.js
@@ -1,11 +1,17 @@
 const cron = require('node-cron');
 const { Pool } = require('pg');
+const fs = require('fs');
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
 });
 
 const MAX_RETRIES = 3;
+
+function logError(message, err) {
+  const log = `${new Date().toISOString()} ${message} ${err?.stack || err}\n`;
+  fs.appendFile('scheduler-error.log', log, () => {});
+}
 
 async function callModel(prompt) {
   const res = await fetch('http://localhost:3000/model', {
@@ -26,6 +32,7 @@ async function processExperiment(exp) {
       return;
     } catch (err) {
       console.error(`Attempt ${attempt} failed for experiment ${exp.id}:`, err);
+      logError(`Experiment ${exp.id} attempt ${attempt} failed`, err);
       if (attempt === MAX_RETRIES) {
         await pool.query('UPDATE prompts SET status = $1 WHERE id = $2', ['failed', exp.id]);
       }
@@ -41,6 +48,7 @@ async function run() {
     }
   } catch (err) {
     console.error('Scheduler run error:', err);
+    logError('Scheduler run error', err);
   }
 }
 


### PR DESCRIPTION
## Summary
- log scheduler errors to a file for later review
- ignore generated log files

## Testing
- `npm test`
- `npm --prefix scheduler test` *(fails: ECONNREFUSED: connect ECONNREFUSED 127.0.0.1:5432)*

------
https://chatgpt.com/codex/tasks/task_e_6890bfc2e4d08322a48724774559b013